### PR TITLE
feat: add options.moduleBasePath - workaround for broken preserveModules

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Options:
 - `publicPath`: Reference file from JS using this path, relative to html page
   where asset is referenced. Could be relative, absolute or CDN.
 - `assetsPath`: Copy assets to this directory, relative to rollup output.
+- `moduleBasePath`: Useful when using module output from rollup (no bundle). Specify the root folder of your modules (usually /src or similar).
 - `useHash`: Use `[hash][ext]` instead of default `[name][ext]`.
 - `keepName`: Use both hash and name `[name]~[hash][ext]` if `useHash` is `true`.
 - `nameFormat`: Use custom name format using these patterns `[name]`, `[ext]`,

--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -22,8 +22,8 @@ function getPublicPathPrefix(publicPath) {
     : ""
 }
 
-function getImportPathPrefix(assetsPath) {
-  return "." + (assetsPath ? "/" + assetsPath : "") + "/"
+function getImportPathPrefix(assetsPath, relativePre) {
+  return (relativePre || ".") + (assetsPath ? "/" + assetsPath : "") + "/"
 }
 
 async function getAssetName(fileName, opts) {
@@ -60,22 +60,23 @@ async function detectOpMode(fileName, options) {
 
 export default (initialOptions = {}) => {
   const defaultOptions = {
-    url: "rebase",        // mode: "rebase" | "inline" | "copy"
-    rebasePath: ".",      // rebase all asset urls to this directory
-    maxSize: 14,          // max size in kbytes that will be inlined, fallback is copy
-    publicPath: null,     // relative to html page where asset is referenced
-    assetsPath: null,     // relative to rollup output
-    useHash: false,       // alias for nameFormat: [hash][ext]
-    keepName: false,      // alias for nameFormat: [name]~[hash][ext] (requires useHash)
-    nameFormat: null,     // valid patterns: [name] | [ext] | [hash]
-    hashOptions: {        // hash options:
-      hash: "sha1",       // "sha1", "md5", "metrohash128", "xxhash64" etc or Hash-like class
-      encoding: "base52", // "hex", "base64", "base62", "base58", "base52" etc
-      maxLength: 8        // truncate final digest to specific length
+    url: "rebase",          // mode: "rebase" | "inline" | "copy"
+    rebasePath: ".",        // rebase all asset urls to this directory
+    maxSize: 14,            // max size in kbytes that will be inlined, fallback is copy
+    publicPath: null,       // relative to html page where asset is referenced
+    assetsPath: null,       // relative to rollup output
+    moduleBasePath: null,   // relative to rollup conf
+    useHash: false,         // alias for nameFormat: [hash][ext]
+    keepName: false,        // alias for nameFormat: [name]~[hash][ext] (requires useHash)
+    nameFormat: null,       // valid patterns: [name] | [ext] | [hash]
+    hashOptions: {          // hash options:
+      hash: "sha1",         // "sha1", "md5", "metrohash128", "xxhash64" etc or Hash-like class
+      encoding: "base52",   // "hex", "base64", "base62", "base58", "base52" etc
+      maxLength: 8          // truncate final digest to specific length
     },
-    keepImport: false,    // keeps import to let another bundler to process the import
-    sourceMap: false,     // add source map if transform() hook is invoked
-    extensions: [         // list of extensions to process by this plugin
+    keepImport: false,      // keeps import to let another bundler to process the import
+    sourceMap: false,       // add source map if transform() hook is invoked
+    extensions: [           // list of extensions to process by this plugin
       ".svg",
       ".gif",
       ".png",
@@ -113,8 +114,9 @@ export default (initialOptions = {}) => {
         } else if (mode === "copy") {
           const assetName = await getAssetName(id, options)
           assetsToCopy.push({ assetName: assetName, fileName: id })
+          const moduleBaseRelative = options.moduleBasePath ? relative(dirname(id), options.moduleBasePath) : ""
           value = options.keepImport
-            ? getImportPathPrefix(options.assetsPath) + assetName
+            ? getImportPathPrefix(options.assetsPath, moduleBaseRelative.replace(/\\/g, "/")) + assetName
             : getPublicPathPrefix(options.publicPath) + assetName
         } else if (mode === "rebase") {
           const assetName = relative(options.rebasePath, id)

--- a/src/smartAsset.test.js
+++ b/src/smartAsset.test.js
@@ -113,6 +113,13 @@ describe("smartAsset()", () => {
     expect(result).toEqual(`${idComment}\nexport default require("./assets/test.png")`)
   })
 
+  test("load(), copy mode with keepImport with assetsPath with moduleBasePath, returns relative asset path as exports", async () => {
+    const options = { url: "copy", keepImport: true, extensions: [".png"], assetsPath: "assets", moduleBasePath: "src/" }
+    const result = await smartAsset(options).load("src/components/atoms/testComponent/test.png")
+
+    expect(result).toEqual(`${idComment}\nexport default require("../../../assets/test.png")`)
+  })
+
   test("load(), copy mode, uses publicPath (no ending slash)", async () => {
     const options = { url: "copy", extensions: [".png"], publicPath: "assets" }
     const result = await smartAsset(options).load("test.png")


### PR DESCRIPTION
Hi,

so I'd like to use your plugin in a component library setting.

I'm generating the components for different output targets (esm, cjs, ...). Some of those components need images and ofcourse the images will be the same in every output target, so I need to move and relink them to a different folder.

Input structure example:
src/components/atoms/myComponent/images/myImage.png

Desired output structure example:
dist/esm/components/atoms/myComponent/images/myImage.js
dist/cjs/components/atoms/myComponent/images/myImage.js
dist/public/componentImages/myImage.png
...

Now I'm using your plugin in copy mode and "assetsPath: '../public/componentImages'". This will move my images to the desired output folder (dist/public/componentImages).

Problem:
In the created myImages.js files the path looks like this `require("./../public/componentImages")`. This wont resolve to the correct file ofcourse.

Solution:
Use `moduleBasePath: "src/" // relative from rollup.config`. That way I can generate the correct relative path to the file by using `path.relative(path.dirname(id), moduleBasePath)`.

New myImage.js content: `require("../../../../../public/componentImages/myImage.png")`


