### PR TITLE
feat: allow to disable emitting files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Main options:
   need to be processed by this plugin.
 - `exclude`: Micromatch pattern or array of micromatch patterns for files that
   NOT need to be processed by this plugin.
+- `emitFiles`: Disable generating files if `false`, by default it's `true` - useful when generating bundle for SSR.
 
 For more details about `include` / `exclude` syntax please refer to:
 <https://github.com/micromatch/micromatch>

--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -111,6 +111,7 @@ export default (initialOptions = {}) => {
     maxSize: 14,              // max size in kbytes that will be inlined, fallback is copy
     publicPath: null,         // relative to html page where asset is referenced
     assetsPath: null,         // relative to rollup output
+    emitFiles: true,
     preserveModules: false,   // should be the same as rollup's preserveModules
     outputDir: null,          // should be the same as output.dir value if preserveModules is set
     inputFile: null,          // should be the same as input.file value if preserveModules is set
@@ -242,7 +243,7 @@ export default (initialOptions = {}) => {
     },
 
     generateBundle(outputOptions, bundle, isWrite) {
-      if (isWrite && assetsToCopy.length) {
+      if (isWrite && assetsToCopy.length && options.emitFiles) {
         const outputDir = outputOptions.dir ? outputOptions.dir : dirname(outputOptions.file)
         const assetsRootPath = join(outputDir, options.assetsPath || "")
 

--- a/src/smartAsset.test.js
+++ b/src/smartAsset.test.js
@@ -331,6 +331,18 @@ describe("smartAsset()", () => {
     expect(copyFileSyncMock).toBeCalledTimes(0)
   })
 
+  test("generateBundle(), copy mode, doesn't copy if emitFiles is false", async () => {
+    const options = { url: "copy", extensions: [".png"], emitFiles: false }
+    const outputOptions = { file: "dist/bundle.js" }
+
+    const plugin = smartAsset(options)
+
+    await plugin.load("test1.png")
+    plugin.generateBundle(outputOptions, {}, false)
+
+    expect(copyFileSyncMock).toBeCalledTimes(0)
+  })
+
   test("generateBundle(), copy mode, warn on copy error", async () => {
     copyFileSyncMock.mockImplementation(() => { throw new Error() })
 


### PR DESCRIPTION
`emitFiles` option allow to control whether the assets should be written to file system or not. In case of generating bundle for SSR, this is needed to avoid cluttering/overwriting assets while still making sure the hashes etc are compatible between server and client bundle.