### PR TITLE
Proper url even on windows

### DIFF
--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -246,7 +246,7 @@ export default (initialOptions = {}) => {
           return buildExportDefaultCode(newAssetPath, idComment)
         }
         case "rebase": {
-          const assetName = relative(options.rebasePath, id)
+          const assetName = normalizeSlashes(relative(options.rebasePath, id));
           const newAssetPath = getAssetPublicPath(assetName, options.publicPath)
           return buildExportDefaultCode(newAssetPath, idComment)
         }

--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -246,7 +246,7 @@ export default (initialOptions = {}) => {
           return buildExportDefaultCode(newAssetPath, idComment)
         }
         case "rebase": {
-          const assetName = normalizeSlashes(relative(options.rebasePath, id));
+          const assetName = normalizeSlashes(relative(options.rebasePath, id))
           const newAssetPath = getAssetPublicPath(assetName, options.publicPath)
           return buildExportDefaultCode(newAssetPath, idComment)
         }

--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -240,7 +240,7 @@ export default (initialOptions = {}) => {
           return buildExportDefaultCode(newAssetPath, idComment)
         }
         case "copy": {
-          const assetName = await getAssetName(id, options)
+          const assetName = normalizeSlashes(await getAssetName(id, options))
           assetsToCopy.push({ assetName, filename: id })
           const newAssetPath = getAssetPublicPath(assetName, options.publicPath)
           return buildExportDefaultCode(newAssetPath, idComment)


### PR DESCRIPTION
I noticed that on windows the url are actually rendered with \\ instead of proper url /. 
Test pass, as far as I can tell. ( On windows I had to adapt the tests expected strings to something account for platform separator.
```js
expect(copyFileSyncMock).nthCalledWith(2, "test2.png", "dist/test2.png".replace(/\//g, sep)); //line 298 in smartAsset.test.js
```
in order to make it work. Since paths on windows are ```\\```  instead of the ```/``` that is used in unix paths.

# This fix should fix following scenarios:

```js
//rollup.config.js
// ...
smartAsset({
    useHash: false,
    keepName: true,
    rebasePath: resolve(process.cwd(), 'node_modules'),
    publicPath: `/my/public/path/vendors`
}),
//...
```
FROM:
```js
// compiled before changes
/* loaded by smart-asset */
var dottedBlue = "/my/public/path/vendors/@vismaux\\nordic-cool\\dist\\img\\spinners\\spinner_dotted_blue_light.svg";
```
TO:
```js
// compiled after changes
/* loaded by smart-asset */
var dottedBlue = "/my/public/path/vendors/@vismaux/nordic-cool/dist/img/spinners/spinner_dotted_blue_light.svg";
```

Note: it was not really affecting the loading of the resource, however, I prefer universal url format style in this case.
Also note: As I looked into the copy mode, I realise that normalizeSlashes does nothing for it, however, if there will ever be the case where, just like @rollup/plugin-url, a [dirname] naming option will be included, the url should still look nice ( i hope so )