### PR TITLE
fix incorrect import path in copy + preserveModules mode

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-05-25T13:05:57Z
+generated_at: 2026-05-25T15:34:13Z
 internal: []
 trusted:
   - action: actions/checkout

--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: 2026-05-25T15:34:13Z
+generated_at: 2026-06-11T15:40:20Z
 internal: []
 trusted:
   - action: actions/checkout

--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,0 +1,22 @@
+version: 1
+generated_at: 2026-05-25T13:05:57Z
+internal: []
+trusted:
+  - action: actions/checkout
+    refs:
+      - v1
+    occurrences:
+      v1:
+        .github/workflows/nodejs.yml:
+          - jobs.build.steps.[0].uses
+  - action: actions/setup-node
+    refs:
+      - v1
+    occurrences:
+      v1:
+        .github/workflows/nodejs.yml:
+          - jobs.build.steps.[1].uses
+external: []
+local: []
+docker: []
+dynamic: []

--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,19 +1,19 @@
 version: 1
-generated_at: 2026-06-11T15:40:20Z
+generated_at: 2026-06-15T13:16:11Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
-      - v1
+      - 50fbc622fc4ef5163becd7fab6573eac35f8462e
     occurrences:
-      v1:
+      50fbc622fc4ef5163becd7fab6573eac35f8462e:
         .github/workflows/nodejs.yml:
           - jobs.build.steps.[0].uses
   - action: actions/setup-node
     refs:
-      - v1
+      - f1f314fca9dfce2769ece7d933488f076716723e
     occurrences:
-      v1:
+      f1f314fca9dfce2769ece7d933488f076716723e:
         .github/workflows/nodejs.yml:
           - jobs.build.steps.[1].uses
 external: []

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,6 +2,9 @@ name: Node CI
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,6 +12,12 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
+    - name: Harden the runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+      with:
+        use-policy-store: true
+        api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
+
     - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [10.x, 12.x, 14.x]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test

--- a/src/smartAsset.js
+++ b/src/smartAsset.js
@@ -45,9 +45,9 @@ function getAssetPublicPath(assetName, publicPath) {
 
 function getAssetImportPath(assetName, assetsPath, context = {}) {
   if (context.preserveModules) {
-    const wrapperFile = join(context.outputDir, relative(dirname(context.inputFile), context.moduleId + ".js"))
+    const importingFile = join(context.outputDir, relative(dirname(context.inputFile), context.importer))
     const assetFile = join(context.outputDir, getAssetImportPath(assetName, assetsPath))
-    const assetRel = relative(dirname(wrapperFile), assetFile)
+    const assetRel = relative(dirname(importingFile), assetFile)
     return markRelative(normalizeSlashes(normalize(assetRel)))
   }
   return markRelative(normalizeSlashes(assetsPath ? join(assetsPath, assetName) : assetName))
@@ -209,6 +209,7 @@ export default (initialOptions = {}) => {
             assetsToCopy.push({ assetName, filename: id })
             const newAssetPath = getAssetImportPath(assetName, options.assetsPath, {
               moduleId: id,
+              importer: importer,
               preserveModules: options.preserveModules,
               outputDir: options.outputDir,
               inputFile: options.inputFile

--- a/src/smartAsset.test.js
+++ b/src/smartAsset.test.js
@@ -156,19 +156,21 @@ describe("smartAsset()", () => {
       expect(result).toEqual({ external: true, id: "./assets/test.png" })
     })
 
-    test("in copy mode with keepImport and preserveModules", async () => {
+    test("in copy mode with keepImport and preserveModules and nested assets, final path works properly", async () => {
       const options = {
         url: "copy",
         preserveModules: true,
         keepImport: true,
-        extensions: [".png"],
-        assetsPath: "../public/assets",
-        inputFile: "src/index.ts",
-        outputDir: "dist/cjs"
+        assetsPath: "assets",
+        outputDir: "build",
+        inputFile: "src/index.ts"
       }
-      const result = await smartAsset(options).resolveId("src/assets/test.png")
+      const source = "./assets/test.png"
+      const importer = `${process.cwd()}/src/components/FancyComponent/FancyComponent.js`
 
-      expect(result).toEqual({ external: true, id: "../../public/assets/test.png" })
+      const result = await smartAsset(options).resolveId(source, importer)
+
+      expect(result).toEqual({ external: true, id: "../../assets/test.png" })
     })
 
     test("in copy mode, uses publicPath (no ending slash)", async () => {


### PR DESCRIPTION
## Description
When using copy + preserveModules, the final import path was incorrect:

e.g. dir structure:
```
src
  components
    ComponentA
      ComponentA.js
      assets
        fancy-asset.svg
```

so the original import was `./assets/fancy-asset.svg`

after building, the structure was:
```
build
  components
    ComponentA
      ComponentA.js
  assets
    fancy-asset.svg
```

but the import path was `../../../assets/fancy-assets.svg` instead of `../../assets/fancy-assets.svg`.

The reason was that the final path was calculated based on the "wrapper file" (i.e. `src/components/ComponentA/assets/fanc-asset.svg.js`) instead of the importing file - I changed the implementation and the existing test.

Let me know if that's fine or perhaps if I should leave the existing case and just add a new one.